### PR TITLE
Transition to pre-built binaries for common platforms

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,8 +1,0 @@
-[target."aarch64-unknown-linux-gnu"]
-# Compressing debug information can yield hundreds of megabytes of savings.
-# The Rust toolchain does not currently perform dead code elimination on
-# debug info.
-#
-# See: https://github.com/rust-lang/rust/issues/56068
-# See: https://reviews.llvm.org/D74169#1990180
-rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,8 @@
+[target."aarch64-unknown-linux-gnu"]
+# Compressing debug information can yield hundreds of megabytes of savings.
+# The Rust toolchain does not currently perform dead code elimination on
+# debug info.
+#
+# See: https://github.com/rust-lang/rust/issues/56068
+# See: https://reviews.llvm.org/D74169#1990180
+rustflags = ["-C", "link-arg=-Wl,--compress-debug-sections=zlib-gabi"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ debug/
 target/
 
 Cargo.lock
-example-govrl
+go-vrl

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,8 @@
-debug/
-target/
 
 Cargo.lock
 go-vrl
+example-govrl
 
-deps/**/build
-deps/**/.rustc_info.json
-deps/**/.cargo-lock
-deps/**/.fingerprint
-deps/**/deps
-deps/**/*.d
-deps/**/CACHEDIR.TAG
+v5/target
+v10/target
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ target/
 
 Cargo.lock
 go-vrl
+
+deps/**/build
+deps/**/.rustc_info.json
+deps/**/.cargo-lock
+deps/**/.fingerprint
+deps/**/deps
+deps/**/*.d
+deps/**/CACHEDIR.TAG

--- a/README.md
+++ b/README.md
@@ -48,11 +48,9 @@ search](https://github.com/vectordotdev/vector/issues?q=is%3Aopen+is%3Aissue+lab
 
 ### Building and importing
 
-Not quite ready yet. It's difficult to distribute a go module that depends on an external build system, we have some ideas though.
-
-To use this repo as-is, its required to manually compile the rust dependency.
-For V5: `cd v5; cargo build --release; cd example/; go run .`
-For V10: `cd v10; cargo build --target wasm32-wasi --release; cd example/; go run .`
+There are pre-built libraries (both static libs for v5 and wasm for v10)
+available in-tree.
+They can be updated using `./produce_artifacts.sh`
 
 ### Examples
 

--- a/produce_artifacts.sh
+++ b/produce_artifacts.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 arch=$(uname -m)
+if [[ "$arch" == "aarch64" ]]; then
+    arch="arm64"
+fi
 plat=$(echo $(uname -s) | awk '{print tolower($0)}')
 
 CARGO_TARGET_DIR="deps/${plat}_${arch}" cargo build --release

--- a/produce_artifacts.sh
+++ b/produce_artifacts.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+arch=$(uname -m)
+plat=$(echo $(uname -s) | awk '{print tolower($0)}')
+
+CARGO_TARGET_DIR="deps/${plat}_${arch}" cargo build --release

--- a/produce_artifacts.sh
+++ b/produce_artifacts.sh
@@ -6,4 +6,8 @@ if [[ "$arch" == "aarch64" ]]; then
 fi
 plat=$(echo $(uname -s) | awk '{print tolower($0)}')
 
-CARGO_TARGET_DIR="deps/${plat}_${arch}" cargo build --release
+$(cd v5; cargo build --release)
+$(cd v10; cargo build --release --target wasm32-wasi)
+
+cp "v5/target/release/libvrl_bridge.a" "v5/deps/${plat}_${arch}/"
+cp "v10/target/wasm32-wasi/release/vrl_bridge.wasm" "v10/deps/"

--- a/v10/Cargo.toml
+++ b/v10/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [profile.release]
-debug=true
+debug=0
 
 [lib]
 name         = "vrl_bridge"

--- a/v10/wasminterface.go
+++ b/v10/wasminterface.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
-//go:embed target/wasm32-wasi/release/vrl_bridge.wasm
+//go:embed deps/vrl_bridge.wasm
 var wasmBytes []byte
 
 type WasmInterface struct {

--- a/v5/Cargo.toml
+++ b/v5/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [profile.release]
-debug=true
+# Emit only the line info tables, not full debug info, in release builds, to
+# substantially reduce the size of the debug info. Line info tables are enough
+# to symbolicate a backtrace, but not enough to use a debugger interactively.
+# This seems to be the right tradeoff for release builds: it's unlikely we're
+# going to get interactive access to a debugger in production installations, but
+# we still want useful crash reports.
+debug = 1
 
 [lib]
 name         = "vrl_bridge"

--- a/v5/Cargo.toml
+++ b/v5/Cargo.toml
@@ -8,8 +8,7 @@ debug=true
 
 [lib]
 name         = "vrl_bridge"
-# crate-type   = ["rlib", "cdylib"]
-crate-type   = ["staticlib"]
+crate-type   = ["cdylib"]
 
 [dependencies]
 libc = "0.2"

--- a/v5/Cargo.toml
+++ b/v5/Cargo.toml
@@ -4,17 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [profile.release]
-# Emit only the line info tables, not full debug info, in release builds, to
-# substantially reduce the size of the debug info. Line info tables are enough
-# to symbolicate a backtrace, but not enough to use a debugger interactively.
-# This seems to be the right tradeoff for release builds: it's unlikely we're
-# going to get interactive access to a debugger in production installations, but
-# we still want useful crash reports.
-debug = 1
+# It would be nice to have debug info, at least `debug=1` (line-level granularity)
+# But unfortunately it balloons the binary size too much
+# With level 0, darwin_arm64 == 57.1
+# With level 1, darwin_arm64 == 149Mi
+debug = 0
 
 [lib]
 name         = "vrl_bridge"
-crate-type   = ["cdylib"]
+crate-type   = ["staticlib"]
 
 [dependencies]
 libc = "0.2"

--- a/v5/program.go
+++ b/v5/program.go
@@ -5,10 +5,10 @@ package govrl
 //#include <string.h>
 //#include <vrl.h>
 //#cgo LDFLAGS: -lvrl_bridge -lm
-//#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64/release -framework CoreFoundation
-//#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64/release -framework CoreFoundation
-//#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/deps/linux_x86_64/release -ldl
-//#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/deps/linux_arm64/release -ldl
+//#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64/release -Wl,-rpath,${SRCDIR}/deps/darwin_x86_64/release -framework CoreFoundation
+//#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64/release -Wl,-rpath,${SRCDIR}/deps/darwin_arm64/release -framework CoreFoundation
+//#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/deps/linux_x86_64/release -Wl,-rpath,${SRCDIR}/deps/linux_x86_64/release -ldl
+//#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/deps/linux_arm64/release -Wl,-rpath,${SRCDIR}/deps/linux_arm64/release -ldl
 import "C"
 import "unsafe"
 

--- a/v5/program.go
+++ b/v5/program.go
@@ -4,8 +4,11 @@ package govrl
 //#include <stdlib.h>
 //#include <string.h>
 //#include <vrl.h>
-//#cgo LDFLAGS: -L${SRCDIR}/target/release -Wl,-rpath,${SRCDIR}/target/release -lvrl_bridge -lm -ldl
-//#cgo darwin,arm64 LDFLAGS: -framework CoreFoundation
+//#cgo LDFLAGS: -lvrl_bridge -lm
+//#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64/release -framework CoreFoundation
+//#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64/release -framework CoreFoundation
+//#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/deps/linux_x86_64/release -ldl
+//#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/deps/linux_arm64/release -ldl
 import "C"
 import "unsafe"
 

--- a/v5/program.go
+++ b/v5/program.go
@@ -5,6 +5,7 @@ package govrl
 //#include <string.h>
 //#include <vrl.h>
 //#cgo LDFLAGS: -L${SRCDIR}/target/release -Wl,-rpath,${SRCDIR}/target/release -lvrl_bridge -lm -ldl
+//#cgo darwin,arm64 LDFLAGS: -framework CoreFoundation
 import "C"
 import "unsafe"
 

--- a/v5/program.go
+++ b/v5/program.go
@@ -5,10 +5,10 @@ package govrl
 //#include <string.h>
 //#include <vrl.h>
 //#cgo LDFLAGS: -lvrl_bridge -lm
-//#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64/release -Wl,-rpath,${SRCDIR}/deps/darwin_x86_64/release -framework CoreFoundation
-//#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64/release -Wl,-rpath,${SRCDIR}/deps/darwin_arm64/release -framework CoreFoundation
-//#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/deps/linux_x86_64/release -Wl,-rpath,${SRCDIR}/deps/linux_x86_64/release -ldl
-//#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/deps/linux_arm64/release -Wl,-rpath,${SRCDIR}/deps/linux_arm64/release -ldl
+//#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64 -Wl,-rpath,${SRCDIR}/deps/darwin_x86_64 -framework CoreFoundation
+//#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64 -Wl,-rpath,${SRCDIR}/deps/darwin_arm64 -framework CoreFoundation
+//#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/deps/linux_x86_64 -Wl,-rpath,${SRCDIR}/deps/linux_x86_64 -ldl
+//#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/deps/linux_arm64 -Wl,-rpath,${SRCDIR}/deps/linux_arm64 -ldl
 import "C"
 import "unsafe"
 

--- a/v5/runtime.go
+++ b/v5/runtime.go
@@ -4,7 +4,6 @@ package govrl
 //#include <stdlib.h>
 //#include <string.h>
 //#include <vrl.h>
-//#cgo LDFLAGS: -L${SRCDIR}/target/release -Wl,-rpath,${SRCDIR}/target/release -lvrl_bridge -lm -ldl
 import "C"
 import "unsafe"
 

--- a/v5/types.go
+++ b/v5/types.go
@@ -4,7 +4,6 @@ package govrl
 //#include <stdlib.h>
 //#include <string.h>
 //#include <vrl.h>
-//#cgo LDFLAGS: -L${SRCDIR}/target/release -Wl,-rpath,${SRCDIR}/target/release -lvrl_bridge -lm -ldl
 import "C"
 import (
 	"runtime"


### PR DESCRIPTION
This project has a usability problem currently where anyone `go get`ing this module will fetch only the code and the requisite `cargo build` step will be missed.

This PR takes inspiration from https://github.com/rogchap/v8go/ and adds pre-built shared libraries (currently) for arm64 darwin and linux platforms.

Out-of-the-box, cargo builds on linux were hilariously huge (see 2d46f2b1329faf3b5fcd04e0adf93d0f59ba575a and f1dc406066bb014998c3b065c30fe3675f0efda3) for more details, so some tricks from https://github.com/MaterializeInc/materialize/pull/2691 were used to get this down to a reasonable size.

TODO:
- [ ] Add linux x86_64
- [ ] Add darwin x86_64
- [x] Test this library in a "client" module to ensure `go get` works as expected
- [ ] Configure release commits that will include the binary blobs