### PR TITLE
Adds module so this is importable by other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ To use this repo as-is. `./run.sh` to build and run `main.go`
 ### Example
 
 ```go
-program, err := CompileWithExternal(`replace(., "go", "rust")`, GetExternalEnv(Bytes, Bytes))
+program, err := govrl.CompileWithExternal(`replace(., "go", "rust")`, govrl.GetExternalEnv(govrl.Bytes, govrl.Bytes))
 if err != nil {
     log.Panicln(err)
 }
 
-runtime := NewRuntime()
-res, err := runtime.resolve(program, "hello go")
+runtime := govrl.NewRuntime()
+res, err := runtime.Resolve(program, "hello go")
 if err != nil {
     log.Panicln(err)
 }
@@ -35,7 +35,7 @@ $ go run .
 "hello rust"
 ```
 
-[see `main.go` for more examples](/main.go)
+[see `./example/main.go` for more examples](./example/main.go)
 
 ## What works
 
@@ -43,13 +43,13 @@ $ go run .
   - Supports bytes and object external environment kinds
 - Initializing the VRL runtime including:
   - `resolve` (run) the compled program
-  - `clear` 
+  - `clear`
   - `is_empty`
 
 ## What doesn't work/missing bindings
 
 - secrets
-- metadata 
+- metadata
 - timezone
 - environment configuration (partially implemented)
 - most input types (other than bytes and object)

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,0 +1,7 @@
+module example-govrl
+
+go 1.18
+
+replace github.com/gh123man/go-vrl => ../
+
+require github.com/gh123man/go-vrl v0.0.0-00010101000000-000000000000

--- a/example/main.go
+++ b/example/main.go
@@ -3,21 +3,23 @@ package main
 import (
 	"fmt"
 	"log"
+
+	govrl "github.com/gh123man/go-vrl"
 )
 
 func main() {
-	BytesEnv()
-	SimpleDefault()
+	bytesEnv()
+	simpleDefault()
 }
 
-func BytesEnv() {
-	program, err := CompileWithExternal(`replace(., "go", "rust")`, GetExternalEnv(Bytes, Bytes))
+func bytesEnv() {
+	program, err := govrl.CompileWithExternal(`replace(., "go", "rust")`, govrl.GetExternalEnv(govrl.Bytes, govrl.Bytes))
 	if err != nil {
 		log.Panicln(err)
 	}
 
-	runtime := NewRuntime()
-	res, err := runtime.resolve(program, "hello go")
+	runtime := govrl.NewRuntime()
+	res, err := runtime.Resolve(program, "hello go")
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -25,8 +27,8 @@ func BytesEnv() {
 	fmt.Println(res)
 }
 
-func SimpleDefault() {
-	program, err := Compile(`
+func simpleDefault() {
+	program, err := govrl.Compile(`
 	. = parse_json!(string!(.))
 	del(.foo)
 
@@ -48,9 +50,9 @@ func SimpleDefault() {
 		return
 	}
 
-	runtime := NewRuntime()
+	runtime := govrl.NewRuntime()
 
-	res, err := runtime.resolve(program, `{
+	res, err := runtime.Resolve(program, `{
 		"message": "Hello VRL",
 		"foo": "delete me",
 		"http_status": "200"
@@ -62,5 +64,5 @@ func SimpleDefault() {
 	}
 
 	fmt.Println(res)
-	runtime.clear()
+	runtime.Clear()
 }

--- a/program.go
+++ b/program.go
@@ -1,4 +1,4 @@
-package main
+package govrl
 
 //#include <stdio.h>
 //#include <stdlib.h>

--- a/runtime.go
+++ b/runtime.go
@@ -1,4 +1,4 @@
-package main
+package govrl
 
 //#include <stdio.h>
 //#include <stdlib.h>
@@ -16,7 +16,7 @@ func NewRuntime() *Runtime {
 	return &runtime
 }
 
-func (r *Runtime) resolve(program *Program, input string) (string, error) {
+func (r *Runtime) Resolve(program *Program, input string) (string, error) {
 	cs := C.CString(input)
 	defer C.free(unsafe.Pointer(cs))
 	result := C.runtime_resolve(r.p, program.p, cs)
@@ -29,10 +29,10 @@ func (r *Runtime) resolve(program *Program, input string) (string, error) {
 	return C.GoString((*C.char)(result.value)), nil
 }
 
-func (r *Runtime) clear() {
+func (r *Runtime) Clear() {
 	C.runtime_clear(r.p)
 }
 
-func (r *Runtime) isEmpty() bool {
+func (r *Runtime) IsEmpty() bool {
 	return C.runtime_is_empty(r.p) != 0
 }

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package main
+package govrl
 
 //#include <stdio.h>
 //#include <stdlib.h>


### PR DESCRIPTION
While the import fails due to non-existent dependent libs, this gets the project closer to be usable as an importable module

Current failure:
```
go run .
# github.com/gh123man/go-vrl
ld: warning: directory not found for option '-L/Users/scott.opell/dev/go-vrl-mod/target/release'
ld: warning: directory not found for option '-L/Users/scott.opell/dev/go-vrl-mod/target/release'
ld: warning: directory not found for option '-L/Users/scott.opell/dev/go-vrl-mod/target/release'
ld: library not found for -lvrl_bridge
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```