### PR TITLE
correctly decode strings from VRL result

### DIFF
--- a/v10/example/main.go
+++ b/v10/example/main.go
@@ -29,7 +29,7 @@ func simpleDefault() {
 	} else {
 		.status = "error"
 	}
-	.
+	. = encode_json(.)
 	`)
 
 	if err != nil {

--- a/v10/src/lib.rs
+++ b/v10/src/lib.rs
@@ -67,7 +67,7 @@ pub extern "C" fn runtime_resolve(
 
     match rt.resolve(&mut target, &prog, &TimeZone::Local) {
         Ok(res) => {
-            let s = res.to_string();
+            let s = res.as_str().unwrap();
             return ((s.as_ptr() as u64) << 32) | s.len() as u64;
         }
         Err(_err) => {

--- a/v5/example/main.go
+++ b/v5/example/main.go
@@ -42,7 +42,7 @@ func simpleDefault() {
 	} else {
 		.status = "error"
 	}
-	.
+	. = encode_json(.)
 	`)
 
 	if err != nil {

--- a/v5/src/lib.rs
+++ b/v5/src/lib.rs
@@ -20,8 +20,6 @@ pub struct CResult<T> {
     error: *mut libc::c_char
 }
 
-
-
 // Compiler
 
 #[no_mangle]
@@ -103,7 +101,7 @@ pub extern "C" fn runtime_resolve(runtime: *mut Runtime, program: *mut Program, 
     match rt.resolve(&mut target, &prog, &TimeZone::Local) {
         Ok(res) => {
             return CResult {
-                value: CString::new(res.to_string().as_bytes()).unwrap().into_raw(),
+                value: CString::new(res.as_str().unwrap().as_bytes()).unwrap().into_raw(),
                 error: std::ptr::null_mut()
             }
         }


### PR DESCRIPTION
`to_string` is a debug function. It often encodes surrounding `"` and has some overhead. 

using `as_str` gives the true raw string representation. 
However - if your VRL program emits an object type, this wont work. As a result I updated the examples to encode the resulting objects as a string. 

Right now go-vrl assumes results will be stringly typed. Until we (if we) implement the full object model of VRL, the burden to convert your result back to a string will be on the VRL program (instead of relying on a debug function as we did previously) 

