### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/v10/example/go.mod
+++ b/v10/example/go.mod
@@ -6,4 +6,4 @@ replace github.com/gh123man/go-vrl/v10 => ../
 
 require github.com/gh123man/go-vrl/v10 v10.0.0
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4 // indirect
+require github.com/tetratelabs/wazero v1.0.1 // indirect

--- a/v10/example/go.sum
+++ b/v10/example/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/v10/go.mod
+++ b/v10/go.mod
@@ -2,4 +2,4 @@ module github.com/gh123man/go-vrl/v10
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/v10/wasminterface.go
+++ b/v10/wasminterface.go
@@ -31,7 +31,7 @@ func NewWasmInterface(ctx context.Context) *WasmInterface {
 	r := wazero.NewRuntime(ctx)
 
 	wasi_snapshot_preview1.MustInstantiate(ctx, r)
-	mod, err := r.InstantiateModuleFromBinary(ctx, wasmBytes)
+	mod, err := r.Instantiate(ctx, wasmBytes)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -85,9 +85,9 @@ func (wr *WasmInterface) newWasmString(input string) *WasmString {
 	ptr := wr.allocate(inputSize)
 
 	// The pointer is a linear memory offset, which is where we write the input string.
-	if !wr.mod.Memory().Write(wr.ctx, uint32(ptr), []byte(input)) {
+	if !wr.mod.Memory().Write(uint32(ptr), []byte(input)) {
 		log.Panicf("Memory.Write(%d, %d) out of range of memory size %d",
-			ptr, len(input), wr.mod.Memory().Size(wr.ctx))
+			ptr, len(input), wr.mod.Memory().Size())
 	}
 
 	ws := WasmString{


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!